### PR TITLE
Allow php >= 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": ">=5.5",
         "phpdocumentor/reflection-common": "^1.0.0",
         "phpdocumentor/type-resolver": "^0.4.0",
         "webmozart/assert": "^1.0"


### PR DESCRIPTION
In commit 007a536 php is dropped. I don't think this was the intention of that commit, this will fix it.
